### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Nvimux uses default neovim terminal implementation for terminal buffers (both qu
 One can define a different quickterm provider via `g:nvimux_quickterm_provider` and different commands for
 terminal creating/closing terminal buffers via `g:nvimux_new_term` and `g:nvimux_close_term`.
 
-###Defining quickterm position
+### Defining quickterm position
 
 You can set specific values for orientation, direction and size with the variables below:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
