### PR TITLE
Fix default bindings not loading

### DIFF
--- a/lua/nvimux.lua
+++ b/lua/nvimux.lua
@@ -291,29 +291,31 @@ end
  -- ]]
 -- ]
 
--- [ Runtime and warmup
-for i=1, 9 do
-  bindings.mappings[i] = { nvit = {i .. 'gt'}}
-end
-
-for key, cmd in pairs(bindings.mappings) do
-  for modes, data in pairs(cmd) do
-    modes = fns.split(modes)
-    local arg, action = unpack(data)
-    local binds = {
-      ['key'] = key,
-      ['modes'] = modes,
-    }
-    if type(arg) == 'function' or action ~= nil then
-      bindings.map_table[key] = {['arg'] = arg, ['action'] = action}
-      binds.value = ':lua require("nvimux").mapped{key = "' .. key .. '"}'
-    else
-      binds.value = arg
+nvimux.bootstrap = function()
+    for i=1, 9 do
+      bindings.mappings[i] = { nvit = {i .. 'gt'}}
     end
-    nvimux.bindings.bind(binds)
-  end
+
+    for key, cmd in pairs(bindings.mappings) do
+      for modes, data in pairs(cmd) do
+        modes = fns.split(modes)
+        local arg, action = unpack(data)
+        local binds = {
+          ['key'] = key,
+          ['modes'] = modes,
+        }
+        if type(arg) == 'function' or action ~= nil then
+          bindings.map_table[key] = {['arg'] = arg, ['action'] = action}
+          binds.value = ':lua require("nvimux").mapped{key = "' .. key .. '"}'
+        else
+          binds.value = arg
+        end
+        nvimux.bindings.bind(binds)
+      end
+    end
 end
 -- ]
 
+nvim.nvim_command([[au VimEnter * lua require('nvimux').bootstrap()]])
 
 return nvimux

--- a/plugin/nvimux.vim
+++ b/plugin/nvimux.vim
@@ -1,6 +1,7 @@
 " Commands
 command! -nargs=0 NvimuxVerticalSplit vspl|wincmd l|enew
 command! -nargs=0 NvimuxHorizontalSplit spl|wincmd j|enew
+
 command! -nargs=0 NvimuxTermPaste lua require('nvimux').term_only{cmd = 'normal pa'}
 command! -nargs=0 NvimuxToggleTerm lua require('nvimux').term.toggle()
 command! -nargs=1 NvimuxTermRename lua require('nvimux').term_only{cmd = 'file term://<args>'}


### PR DESCRIPTION
Default bindings were being bound at nvimux load, not allowing custom prefix to be used. This fixes #9.