### PR TITLE
vim.tbl_deep_extend is for map-type tables

### DIFF
--- a/lua/nvimux/init.lua
+++ b/lua/nvimux/init.lua
@@ -337,7 +337,10 @@ nvimux.setup = function(opts)
   vars = vim.tbl_deep_extend("force", vars or {}, opts.config or {})
 
   local context = vars
-  context.bindings = vim.tbl_deep_extend("force", mappings, opts.bindings or {})
+  context.bindings = mappings
+  for _, b in ipairs(opts.bindings) do
+    table.insert(context.bindings, b)
+  end
 
   for _, binding in ipairs(context.bindings) do
     bindings.keymap(binding, context)


### PR DESCRIPTION
I'm not quite sure what the plan is in the transition from bootstrap() to
setup() but vim.tbl_deep_extend is for map-type tables and the new bindings
layout is not that, but rather a list-type table. Accordingly, this works
better.
