### PR TITLE
Remove deprecated functions

### DIFF
--- a/lua/nvimux/bindings.lua
+++ b/lua/nvimux/bindings.lua
@@ -33,8 +33,6 @@ end
 bindings.keymap = function(binding, context)
   local options = {silent = true}
 
-  print(vim.inspect(binding))
-
   if (type(binding[3]) == "function") then
     bindings.set_keymap(binding[1], context.prefix .. binding[2], binding[3], options)
   elseif (type(binding[3]) == "string") then

--- a/lua/nvimux/bindings.lua
+++ b/lua/nvimux/bindings.lua
@@ -4,7 +4,6 @@ local fns = {}
 
 local consts = {
   terminal_quit = '<C-\\><C-n>',
-  esc = '<ESC>',
 }
 
 if vim.keymap ~= nil then
@@ -40,26 +39,29 @@ bindings.keymap = function(binding, context)
     bindings.set_keymap(binding[1], context.prefix .. binding[2], binding[3], options)
   elseif (type(binding[3]) == "string") then
     local suffix = ''
+    local starts_with_colon = string.sub(binding[3], 1, 1) == ':'
 
     if binding.suffix == nil then
       -- TODO revisit
-      suffix = string.sub(binding[3], 1, 1) == ':' and '<CR>' or ''
+      suffix = starts_with_colon and '<CR>' or ''
     else
       suffix = binding.suffix
     end
 
-    if vim.tbl_contains(binding[1], 't') then
-      binding[1] = vim.tbl_filter(function(mode) return mode ~= 't' end, binding[1])
-      bindings.set_keymap('t',
-        context.prefix .. binding[2],
-        consts.terminal_quit .. binding[3] .. suffix,
-        options)
-    elseif vim.tbl_contains(binding[1], 'i') then
-      binding[1] = vim.tbl_filter(function(mode) return mode ~= 'i' end, binding[1])
-      bindings.set_keymap('i',
-        context.prefix .. binding[2],
-        consts.esc .. binding[3] .. suffix,
-        options)
+    if starts_with_colon then
+      if vim.tbl_contains(binding[1], 't') then
+        binding[1] = vim.tbl_filter(function(mode) return mode ~= 't' end, binding[1])
+        bindings.set_keymap('t',
+          context.prefix .. binding[2],
+          consts.terminal_quit .. binding[3] .. suffix,
+          options)
+      elseif vim.tbl_contains(binding[1], 'i') then
+        binding[1] = vim.tbl_filter(function(mode) return mode ~= 'i' end, binding[1])
+        bindings.set_keymap('i',
+          context.prefix .. binding[2],
+          consts.esc .. binding[3] .. suffix,
+          options)
+      end
     end
 
     bindings.set_keymap(binding[1], context.prefix .. binding[2], binding[3] .. suffix, options)

--- a/lua/nvimux/bindings.lua
+++ b/lua/nvimux/bindings.lua
@@ -7,50 +7,6 @@ local consts = {
   esc = '<ESC>',
 }
 
-fns.nvim_do_bind = function(options)
-    local escape_prefix = options.escape_prefix  or ''
-    local mode = options.mode
-    return function(cfg)
-      local suffix = cfg.suffix
-      local prefix = vars.local_prefix[mode] or vars.prefix
-      if suffix == nil then
-        suffix = string.sub(cfg.mapping, 1, 1) == ':' and '<CR>' or ''
-      end
-      vim.cmd(mode .. 'noremap <silent> ' .. prefix .. cfg.key .. ' ' .. escape_prefix .. cfg.mapping .. suffix)
-  end
-end
-
-fns.bind = {
-  t = fns.nvim_do_bind{mode = 't', escape_prefix = consts.terminal_quit},
-  i = fns.nvim_do_bind{mode = 'i', escape_prefix = consts.esc},
-  n = fns.nvim_do_bind{mode = 'n'},
-  v = fns.nvim_do_bind{mode = 'v'}
-}
-
-fns.bind_all_modes = function(options)
-  for _, mode in ipairs(options.modes) do
-    fns.bind[mode](options)
-  end
-end
-
-bindings.bind = function(options)
-  fns.bind_all_modes(options)
-end
-
-bindings.create_binding = function(modes, command)
-    local tbl = {}
-    tbl[table.concat(modes, "")] = { command }
-    return tbl
-
-end
-
-bindings.bind_all = function(options)
-  for _, bind in ipairs(options) do
-    local key, cmd, modes = unpack(bind)
-    bindings.mappings[key] = bindings.create_binding(modes, cmd)
-  end
-end
-
 if vim.keymap ~= nil then
   bindings.set_keymap = vim.keymap.set
 else
@@ -77,6 +33,8 @@ end
 
 bindings.keymap = function(binding, context)
   local options = {silent = true}
+
+  print(vim.inspect(binding))
 
   if (type(binding[3]) == "function") then
     bindings.set_keymap(binding[1], context.prefix .. binding[2], binding[3], options)

--- a/lua/nvimux/fns.lua
+++ b/lua/nvimux/fns.lua
@@ -1,12 +1,5 @@
 local fns = {}
 
-fns.prompt = function(message)
-  vim.fn.inputsave()
-  local ret = vim.fn.input(message)
-  vim.fn.inputrestore()
-  return ret
-end
-
 fns.split = function(str)
   local p = {}
   for i=1, #str do

--- a/lua/nvimux/fns.lua
+++ b/lua/nvimux/fns.lua
@@ -1,28 +1,23 @@
 local fns = {}
 
-fns.split = function(str)
-  local p = {}
-  for i=1, #str do
-    table.insert(p, str:sub(i, i))
-  end
-  return p
-end
-
-fns.build_cmd = function(options)
-  local nargs = options.nargs or 0
-  local cmd = options.cmd or options.lazy_cmd()
-
-  vim.cmd('command! -nargs=' .. nargs .. ' ' .. options.name .. ' ' .. cmd)
-end
-
-
 local function capitalize_first(s)
-	return string.upper(string.sub(s,1,1))..string.sub(s,2)
-end
-local function to_pascal(s)
-	return (string.gsub(capitalize_first(s),"_(%w+)",capitalize_first))
+  return string.upper(string.sub(s,1,1))..string.sub(s,2)
 end
 
-fns.snake_to_pascal = to_pascal
+fns.snake_to_pascal = function(s)
+  return (string.gsub(capitalize_first(s),"_(%w+)",capitalize_first))
+end
+
+fns.fn_or_command = function(cmd)
+  local tp = type(cmd)
+  if tp == "function" then
+    cmd()
+  elseif tp == "string" then
+    vim.cmd(cmd)
+  else
+    print("nvimux: Cannot run command of type " .. tp)
+  end
+end
+
 
 return fns

--- a/lua/nvimux/fns.lua
+++ b/lua/nvimux/fns.lua
@@ -15,4 +15,14 @@ fns.build_cmd = function(options)
   vim.cmd('command! -nargs=' .. nargs .. ' ' .. options.name .. ' ' .. cmd)
 end
 
+
+local function capitalize_first(s)
+	return string.upper(string.sub(s,1,1))..string.sub(s,2)
+end
+local function to_pascal(s)
+	return (string.gsub(capitalize_first(s),"_(%w+)",capitalize_first))
+end
+
+fns.snake_to_pascal = to_pascal
+
 return fns

--- a/lua/nvimux/init.lua
+++ b/lua/nvimux/init.lua
@@ -7,7 +7,6 @@
 
 local nvimux = {}
 local bindings = require('nvimux.bindings')
-local vars = require('nvimux.vars')
 local fns = require('nvimux.fns')
 
 nvimux.bindings = bindings
@@ -178,10 +177,6 @@ local mappings = {
 
 -- ]]
 
-setmetatable(vars, nvim_proxy)
-
--- ]
-
 --- Configure nvimux to start with the supplied arguments
 -- It can be configured to use the defaults by only supplying an empty table.
 -- This function must be called to initalize nvimux.
@@ -192,10 +187,8 @@ setmetatable(vars, nvim_proxy)
 -- @tparam opts.autocmds table autocmds that belong to the same logical group than nvimux
 -- @see nvimux.vars for the defaults
 nvimux.setup = function(opts)
-  -- TODO Remove global vars, make it local to context only
-  vars = vim.tbl_deep_extend("force", vars or {}, opts.config or {})
+  local context = vim.tbl_deep_extend("force", require('nvimux.vars'), opts.config or {})
 
-  local context = vars
   context.bindings = mappings
   for _, b in ipairs(opts.bindings) do
     table.insert(context.bindings, b)

--- a/lua/nvimux/init.lua
+++ b/lua/nvimux/init.lua
@@ -132,21 +132,21 @@ local autocmds = {
 
 local mappings = {
   -- Reload global configs
-  {{'n', 'v', 'i'},      '<C-r>', ':so $MYVIMRC'},
+  {{'n', 'v', 'i'},      '<C-r>', '<Cmd>source $MYVIMRC'},
 
   -- Window management
-  {{'n', 'v', 'i', 't'}, '!',  ':wincmd T'},
+  {{'n', 'v', 'i', 't'}, '!',  '<Cmd>wincmd T'},
   {{'n', 'v', 'i', 't'}, '%',  nvimux.commands.vertical_split},
   {{'n', 'v', 'i', 't'}, '\"', nvimux.commands.horizontal_split},
   {{'n', 'v', 'i', 't'}, '-',  nvimux.go_to_last_tab},
   {{'n', 'v', 'i', 't'}, 'q',  nvimux.term.toggle },
-  {{'n', 'v', 'i', 't'}, 'w',  ':tabs'},
+  {{'n', 'v', 'i', 't'}, 'w',  '<Cmd>tabs'},
   {{'n', 'v', 'i', 't'}, 'o',  '<C-w>w'},
   {{'n', 'v', 'i', 't'}, 'n',  'gt'},
   {{'n', 'v', 'i', 't'}, 'p',  'gT'},
-  {{'n', 'v', 'i'},      'x',  ':bd %'},
+  {{'n', 'v', 'i'},      'x',  '<Cmd>bdelete %'},
   {{'t'},                'x',  function() vim.api.nvim_buf_delete(0, {force = true}) end},
-  {{'n', 'v', 'i'},      'X',  ':enew \\| bd #'},
+  {{'n', 'v', 'i'},      'X',  '<Cmd>enew \\| bd #'},
 
   -- Moving around
   {{'n', 'v', 'i', 't'}, 'h',  '<C-w><C-h>'},
@@ -156,8 +156,8 @@ local mappings = {
 
   -- Term facilities
   {{'t'},                ':',  ':', suffix = ''},
-  {{'t'},                '[',  ''},
-  {{'t'},                ']',  function() nvimux.term_only{cmd = 'normal pa'} end},
+  {{'t'},                '[',  '<C-\\><C-n>'},
+  {{'t'},                ']',  function() vim.paste(vim.fn.getreg('"', 1, true), -1) end },
   {{'t', 'n'},           ',',  nvimux.term.rename},
 
   -- Tab management

--- a/lua/nvimux/init.lua
+++ b/lua/nvimux/init.lua
@@ -27,35 +27,13 @@ __newindex = function(tbl, key, value)
 bindings.map_table = {}
 
 local win_cmd = function(create_window)
-      local select_buffer
-      vim.cmd(create_window)
-
-    if type(vars.new_window) == "function" then
-      select_buffer = vars.new_window
-    else
-      select_buffer = function()
-        vim.api.nvim_command(vars.new_window)
-      end
-    end
-
-    select_buffer()
+  vim.cmd(create_window)
+  fns.fn_or_command(nvimux.context.new_window)
 end
 
 local tab_cmd = function(create_window)
-  local select_buffer
   vim.cmd(create_window)
-
-  local selector = nvimux.context.new_tab or nvimux.context.new_window
-
-  if type(selector) == "function" then
-    select_buffer = selector
-  else
-    select_buffer = function()
-      vim.api.nvim_command(selector)
-    end
-  end
-
-  select_buffer()
+  fns.fn_or_command(nvimux.context.new_tab)
 end
 
 -- [[ Commands

--- a/lua/nvimux/init.lua
+++ b/lua/nvimux/init.lua
@@ -9,7 +9,6 @@ local nvimux = {}
 local bindings = require('nvimux.bindings')
 local fns = require('nvimux.fns')
 
-nvimux.bindings = bindings
 nvimux.config = {}
 nvimux.term = {}
 nvimux.commands = setmetatable({},{

--- a/lua/nvimux/vars.lua
+++ b/lua/nvimux/vars.lua
@@ -22,13 +22,13 @@ local singleton_buf = function()
 end
 
 
-vars.local_prefix = {
-    n = nil,
-    v = nil,
-    i = nil,
-    t = nil
-  }
-
+--- Quickterm configuration
+-- @table quickterm
+-- @field scope Scope of quickterm. Can be one of: 'b', 'w', 't', 'g'
+-- @field direction nvim's window direction
+-- @field orientation nvim's window orientation
+-- @field size size in columns/rows depending on orientation
+-- @field command nvim command or lua function for the quickterm
 vars.quickterm = {
   scope = 'g',
   direction = 'botright',
@@ -38,30 +38,34 @@ vars.quickterm = {
 }
 
 vars.prefix = '<C-b>'
--- Deprecated
-vars.vertical_split = ':NvimuxVerticalSplit'
-vars.horizontal_split = ':NvimuxHorizontalSplit'
 
-vars.close_term = function()
-    vim.api.nvim_buf_delete(0, {force = true})
-end
-
+--- Defines what is going to be displayed when a buffer is
+-- required for a new window/tab.
+-- By default, that content will be created once on a
+-- non-listed scratch buffer.
 vars.scratch_buf_content = {
   ""
 }
 
-vars.new_buffer = function()
-  return vim.api.nvim_create_buf(false, true)
-end
-
+--- Prepares a new window
+--  Can be used to display dashboards, TODO lists or as a hook to invoke
+--  other functions (like telescope).
+-- Defaults to setting a scratch buffer whose contents are defined by
+-- @{\\vars.scratch_buf_content}.
 vars.new_window = function()
     vim.api.nvim_set_current_buf(singleton_buf())
 end
 
+--- Prepares a new tab
+-- Can be used to display dashboards, TODO lists or as a hook to invoke
+-- other functions (like telescope).
+-- Defaults to setting a scratch buffer whose contents are defined by
+-- @{\\vars.scratch_buf_content}.
 vars.new_tab = function()
     vim.api.nvim_set_current_buf(singleton_buf())
 end
 
+--- Prepares the command that will be executed to create a new quickterm
 vars.quickterm.split_type = function(t)
   return t.direction .. ' ' .. t.orientation .. ' ' .. t.size .. 'split'
 end

--- a/plugin/nvimux.vim
+++ b/plugin/nvimux.vim
@@ -1,8 +1,0 @@
-" Commands
-command! -nargs=0 NvimuxTermPaste lua require('nvimux').term_only{cmd = 'normal pa'}
-command! -nargs=0 NvimuxToggleTerm lua require('nvimux').term.toggle()
-command! -nargs=1 NvimuxTermRename lua require('nvimux').term_only{cmd = 'file term://<args>'}
-
-command! -nargs=0 NvimuxHorizontalSplit lua require('nvimux').commands.horizontal_split()
-command! -nargs=0 NvimuxVerticalSplit lua require('nvimux').commands.vertical_split()
-command! -nargs=0 NvimuxNewTab lua require('nvimux').commands.new_tab()


### PR DESCRIPTION
Also, this PR contains a few nice improvements:
- Allow for `<Cmd>` mappings, avoiding autocmds
- Drop viml commands in favor of lua-centric commands:
  - This should avoid back-and-forth swapping between lua and viml;
  - It should also allow for simpler to understand (i.e. centralized) code
- Make use of newer nvim apis:
  - Most notably pasting without resorting to `normal pa` and other hacks.


Hopefully nothing changes to the user, but if anything the responsiveness should improve with those small tweaks.